### PR TITLE
Passing App ID

### DIFF
--- a/src/resolvers/current-weather.js
+++ b/src/resolvers/current-weather.js
@@ -1,24 +1,24 @@
-const axios = require('axios')
 const { addUnits, get } = require('../utils');
 
-const APPID = process.env.APP_ID
-const CURRENT_WEATHER_URL = `https://api.openweathermap.org/data/2.5/weather?${APPID}`
+const CURRENT_WEATHER_URL = 'https://api.openweathermap.org/data/2.5/weather';
 
 module.exports = {
-  byCityName: (_, { name, countryCode, units }) => {
-    const location = [name]
+  byCityName: ({ appId }, { name, countryCode, units }) => {
+    const location = [name];
     if (countryCode && countryCode.trim()) {
-      location.push(countryCode.trim())
+      location.push(countryCode.trim());
     }
-    return get(`${CURRENT_WEATHER_URL}&q=${location.join()}${addUnits(units)}`)
+    return get(`${CURRENT_WEATHER_URL}?APPID=${appId}&q=${location.join()}${addUnits(units)}`);
   },
-  byCityID: (_, { id, units }) => get(`${CURRENT_WEATHER_URL}&id=${id}${addUnits(units)}`),
-  byLatLon: (_, { lat, lon, units }) => get(`${CURRENT_WEATHER_URL}&lat=${lat}&lon=${lon}${addUnits(units)}`),
-  byZIP: (_, { zip, countryCode, units }) => {
-    const location = [zip]
+  byCityID: ({ appId }, { id, units }) =>
+    get(`${CURRENT_WEATHER_URL}?APPID=${appId}&id=${id}${addUnits(units)}`),
+  byLatLon: ({ appId }, { lat, lon, units }) =>
+    get(`${CURRENT_WEATHER_URL}?APPID=${appId}&lat=${lat}&lon=${lon}${addUnits(units)}`),
+  byZIP: ({ appId }, { zip, countryCode, units }) => {
+    const location = [zip];
     if (countryCode && countryCode.trim()) {
-      location.push(countryCode.trim())
+      location.push(countryCode.trim());
     }
-    return get(`${CURRENT_WEATHER_URL}&zip=${location.join()}${addUnits(units)}`)
+    return get(`${CURRENT_WEATHER_URL}?APPID=${appId}&zip=${location.join()}${addUnits(units)}`);
   }
-}
+};

--- a/src/resolvers/five-day-forecast.js
+++ b/src/resolvers/five-day-forecast.js
@@ -1,23 +1,23 @@
 const { addUnits, get } = require('../utils');
-
-const APPID = process.env.APP_ID
-const CURRENT_FORECAST_URL = `https://api.openweathermap.org/data/2.5/forecast?${APPID}`
+const CURRENT_FORECAST_URL = `https://api.openweathermap.org/data/2.5/forecast`;
 
 module.exports = {
-  byCityName: (_, { name, countryCode, units }) => {
-    const location = [name]
+  byCityName: ({ appId }, { name, countryCode, units }) => {
+    const location = [name];
     if (countryCode && countryCode.trim()) {
-      location.push(countryCode.trim())
+      location.push(countryCode.trim());
     }
-    return get(`${CURRENT_FORECAST_URL}&q=${location.join()}${addUnits(units)}`)
+    return get(`${CURRENT_FORECAST_URL}?APPID=${appId}&q=${location.join()}${addUnits(units)}`);
   },
-  byCityID: (_, { id, units }) => get(`${CURRENT_FORECAST_URL}&id=${id}${addUnits(units)}`),
-  byLatLon: (_, { lat, lon, units }) => get(`${CURRENT_FORECAST_URL}&lat=${lat}&lon=${lon}${addUnits(units)}`),
-  byZIP: (_, { zip, countryCode, units }) => {
-    const location = [zip]
+  byCityID: ({ appId }, { id, units }) =>
+    get(`${CURRENT_FORECAST_URL}?${appId}&id=${id}${addUnits(units)}`),
+  byLatLon: ({ appId }, { lat, lon, units }) =>
+    get(`${CURRENT_FORECAST_URL}?APPID=${appId}&lat=${lat}&lon=${lon}${addUnits(units)}`),
+  byZIP: ({ appId }, { zip, countryCode, units }) => {
+    const location = [zip];
     if (countryCode && countryCode.trim()) {
-      location.push(countryCode.trim())
+      location.push(countryCode.trim());
     }
-    return get(`${CURRENT_FORECAST_URL}&zip=${location.join()}${addUnits(units)}`)
+    return get(`${CURRENT_FORECAST_URL}?APPID=${appId}&zip=${location.join()}${addUnits(units)}`);
   }
-}
+};

--- a/src/resolvers/query.js
+++ b/src/resolvers/query.js
@@ -1,4 +1,6 @@
+const simpleResolve = (_, { appId }) => ({ appId });
+
 module.exports = {
-  currentWeather: () => ({}),
-  fiveDayForecast: () => ({})
-}
+  currentWeather: simpleResolve,
+  fiveDayForecast: simpleResolve
+};

--- a/src/schema/query.graphql
+++ b/src/schema/query.graphql
@@ -2,6 +2,6 @@
 # import FiveDayForecast from "five-day-forecast.graphql"
 
 type Query {
-  currentWeather: CurrentWeather
-  fiveDayForecast: FiveDayForecast
+  currentWeather(appId: String!): CurrentWeather
+  fiveDayForecast(appId: String!): FiveDayForecast
 }


### PR DESCRIPTION
## Changes

#### ✨ (query) adding appId as arg  [cea79e6]
adds argument to root queries for passing App ID

#### ✨ (root resolvers) using appId that's passed from parent to make API requests [cc7ab6b]


## TL;DR
allows clients to pass own app Id into application
```gql
{
  currentWeather(appId: "SOME_APP_ID") {
    byCityName(name: "Savannah,US", units: metric) {
      wind {
        speed
        deg
      }
      weather {
        description
      }
    }
  }
}
```