### PR TITLE
Moving units to root

### DIFF
--- a/src/resolvers/current-weather.js
+++ b/src/resolvers/current-weather.js
@@ -3,7 +3,7 @@ const { get } = require('../utils');
 const CURRENT_WEATHER_URL = 'https://api.openweathermap.org/data/2.5/weather';
 
 module.exports = {
-  byCityName: ({ appId, lang }, { name, countryCode, units }) => {
+  byCityName: ({ appId, lang, units }, { name, countryCode }) => {
     const location = [name];
     if (countryCode && countryCode.trim()) {
       location.push(countryCode.trim());
@@ -14,20 +14,20 @@ module.exports = {
       lang
     });
   },
-  byCityID: ({ appId, lang }, { id, units }) =>
+  byCityID: ({ appId, lang, units }, { id }) =>
     get(CURRENT_WEATHER_URL, appId, {
       units,
       lang,
       id
     }),
-  byLatLon: ({ appId, lang }, { lat, lon, units }) =>
+  byLatLon: ({ appId, lang, units }, { lat, lon }) =>
     get(CURRENT_WEATHER_URL, appId, {
       lat,
       lon,
       units,
       lang
     }),
-  byZIP: ({ appId, lang }, { zip, countryCode, units }) => {
+  byZIP: ({ appId, lang, units }, { zip, countryCode }) => {
     const location = [zip];
     if (countryCode && countryCode.trim()) {
       location.push(countryCode.trim());

--- a/src/resolvers/five-day-forecast.js
+++ b/src/resolvers/five-day-forecast.js
@@ -2,7 +2,7 @@ const { get } = require('../utils');
 const CURRENT_FORECAST_URL = `https://api.openweathermap.org/data/2.5/forecast`;
 
 module.exports = {
-  byCityName: ({ appId, lang }, { name, countryCode, units }) => {
+  byCityName: ({ appId, lang, units }, { name, countryCode }) => {
     const location = [name];
     if (countryCode && countryCode.trim()) {
       location.push(countryCode.trim());
@@ -14,20 +14,20 @@ module.exports = {
       lang
     });
   },
-  byCityID: ({ appId, lang }, { id, units }) =>
+  byCityID: ({ appId, lang, units }, { id }) =>
     get(CURRENT_FORECAST_URL, appId, {
       id,
       units,
       lang
     }),
-  byLatLon: ({ appId, lang }, { lat, lon, units }) =>
+  byLatLon: ({ appId, lang, units }, { lat, lon }) =>
     get(CURRENT_FORECAST_URL, appId, {
       lat,
       lon,
       units,
       lang
     }),
-  byZIP: ({ appId, lang }, { zip, countryCode, units }) => {
+  byZIP: ({ appId, lang, units }, { zip, countryCode }) => {
     const location = [zip];
     if (countryCode && countryCode.trim()) {
       location.push(countryCode.trim());

--- a/src/resolvers/query.js
+++ b/src/resolvers/query.js
@@ -1,4 +1,4 @@
-const simpleResolve = (_, { appId, lang }) => ({ appId, lang });
+const simpleResolve = (_, args) => args;
 
 module.exports = {
   currentWeather: simpleResolve,

--- a/src/schema/current-weather.graphql
+++ b/src/schema/current-weather.graphql
@@ -1,12 +1,11 @@
 # import Coordinate, Weather, Main, Clouds, Rain, Snow from "shared.graphql"
 
 type CurrentWeather {
-  byCityName(name: String!, countryCode: String, units: Units): CurrentWeatherResponse
-  byCityID(id: Int!, units: Units): CurrentWeatherResponse
-  byLatLon(lat: Float!, lon: Float!, units: Units): CurrentWeatherResponse
-  byZIP(zip: Float!, countryCode: String, units: Units): CurrentWeatherResponse
+  byCityName(name: String!, countryCode: String): CurrentWeatherResponse
+  byCityID(id: Int!): CurrentWeatherResponse
+  byLatLon(lat: Float!, lon: Float!): CurrentWeatherResponse
+  byZIP(zip: Float!, countryCode: String): CurrentWeatherResponse
 }
-
 
 type CurrentWeatherResponse {
   coord: Coordinate

--- a/src/schema/five-day-forecast.graphql
+++ b/src/schema/five-day-forecast.graphql
@@ -15,14 +15,13 @@ type FiveDayForecastResponse {
   cod: String
   message: String
   city: City
-  elementCount: Int,
+  elementCount: Int
   list: [FiveDayForecastElement]
 }
 
 type FiveDayForecast {
-  byCityName(name: String!, countryCode: String, units: Units): FiveDayForecastResponse
+  byCityName(name: String!, countryCode: String): FiveDayForecastResponse
   byCityID(id: Int!, units: Units): FiveDayForecastResponse
-  byLatLon(lat: Float!, lon: Float!, units: Units): FiveDayForecastResponse
-  byZIP(zip: Float!, countryCode: String, units: Units): FiveDayForecastResponse
+  byLatLon(lat: Float!, lon: Float!): FiveDayForecastResponse
+  byZIP(zip: Float!, countryCode: String): FiveDayForecastResponse
 }
-

--- a/src/schema/query.graphql
+++ b/src/schema/query.graphql
@@ -1,8 +1,8 @@
 # import CurrentWeather from "current-weather.graphql"
 # import FiveDayForecast from "five-day-forecast.graphql"
-# import Language from "shared.graphql"
+# import Language, Units from "shared.graphql"
 
 type Query {
-  currentWeather(appId: String!, lang: Language = en): CurrentWeather
-  fiveDayForecast(appId: String!, lang: Language = en): FiveDayForecast
+  currentWeather(appId: String!, lang: Language = en, units: Units = standard): CurrentWeather
+  fiveDayForecast(appId: String!, lang: Language = en, units: Units = standard): FiveDayForecast
 }

--- a/src/schema/shared.graphql
+++ b/src/schema/shared.graphql
@@ -1,6 +1,7 @@
 enum Units {
   metric
   imperial
+  standard
 }
 
 enum Language {


### PR DESCRIPTION
## Changes
#### ✨ (units enum) adding `standard` units  [4cdaea2]
adds 'standard' units (metric, but with kelvin)

#### ✨ (g cz) adding units arg to root queries  [1d63e2e]
adds `units` to root queries, sets default value as `standard`

#### ♻️ (resolvers) using units from root  [bfcc3c7]
replaces existing `units` param with one from root of query

#### 🔥 (schema) removing units param from fields  [10e7f23]
* removes `units` param from fields of `CurrentWeather` and `FiveDayForecast`

## TL;DR
moves `units` param from sub fields into root fields
